### PR TITLE
always run in headFULL browser locally for better debugging, and solves SOME weird issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octomind/debugtopus",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Thin wrapper around playwright and the octomind api to run your automagically-maintained tests locally",
   "main": "./dist/index.js",
   "packageManager": "pnpm@9.5.0+sha256.dbdf5961c32909fb030595a9daa1dae720162e658609a8f92f2fa99835510ca5",

--- a/src/debugtopus.ts
+++ b/src/debugtopus.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from "@playwright/test";
 // noinspection JSUnusedGlobalSymbols
 export default defineConfig({
   use: {
+    headless: false,
     baseURL: "${url}",
   },
   timeout: 600_000,

--- a/tests/debugtopus.spec.ts
+++ b/tests/debugtopus.spec.ts
@@ -151,7 +151,13 @@ describe("debugtopus", () => {
     it("should override the timeout", () => {
       const config = getConfig("doesn't/matter", "./someDir");
 
-      expect(config).toContain("timeout: 600_00");
+      expect(config).toContain("timeout: 600_000");
+    });
+
+    it("should run a non-headless browser", () => {
+      const config = getConfig("doesn't/matter", "./someDir");
+
+      expect(config).toContain("headless: false");
     });
   });
 


### PR DESCRIPTION
related to https://github.com/OctoMind-dev/automagically/pull/3917